### PR TITLE
启动上下文操作的模式状态改为false

### DIFF
--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -22,7 +22,7 @@ const appStore = useAppStore()
 
 appStore.setTheme('dark')
 
-const isCorrelation = ref(true)
+const isCorrelation = ref(false)
 
 let controller = new AbortController()
 


### PR DESCRIPTION
目前每次打开都默认勾选上了，大部分时候可能不需要勾选