### PR TITLE
fix: 修改了当输入/显示提示语以后无法进行删除/的问题

### DIFF
--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -322,6 +322,10 @@ async function onConversation() {
 }
 
 function handleEnter(event: KeyboardEvent) {
+  // 如果输入的是/,并且按下的键是删除键，同时prompt.value的值只有/则把prompt.value的值置空
+  if (event.key === 'Backspace' && prompt.value === '/')
+    prompt.value = ''
+
   // 输入 prompt / 重新获取焦点 第一次 / prompt.value时空字符
   if (event.key === '/' && !prompt.value) {
     setTimeout(() => {

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -26,6 +26,7 @@ const appStore = useAppStore()
 
 const prompt = ref<string>('')
 const loading = ref<boolean>(false)
+const NInputRef = ref<HTMLInputElement | null>(null)
 const NSelectRef = ref<HTMLInputElement | null>(null)
 
 if (!localStorage.getItem('chatMossPiecesNumber'))
@@ -321,6 +322,13 @@ async function onConversation() {
   }
 }
 
+const handleSelectInput = (event: any) => {
+  prompt.value = event.data
+  setTimeout(() => {
+    NInputRef.value?.focus()
+  }, 200)
+}
+
 function handleEnter(event: KeyboardEvent) {
   // 如果输入的是/,并且按下的键是删除键，同时prompt.value的值只有/则把prompt.value的值置空
   if (event.key === 'Backspace' && prompt.value === '/')
@@ -560,13 +568,13 @@ async function onSuccessAuth() {
       <div class="w-full max-w-screen-xl m-auto">
         <div class="moss-btns flex justify-between space-x-2">
           <NInput
-            v-if="!prompt || prompt[0] !== '/'" v-model:value="prompt" class="step1" autofocus type="textarea"
+            v-if="!prompt || prompt[0] !== '/'" ref="NInputRef" v-model:value="prompt" class="step1" autofocus type="textarea"
             :autosize="{ minRows: 3, maxRows: 3 }" :placeholder="placeholder" @keydown="handleEnter"
           />
           <NSelect
             v-if="prompt && prompt[0] === '/'" ref="NSelectRef" v-model:value="prompt" filterable :show="true"
             :autofocus="true" :autosize="{ minRows: 3, maxRows: 3 }" placeholder="placeholder" :options="selectOption"
-            label-field="key" @keydown="handleEnter"
+            label-field="key" @keydown="handleEnter" @input="handleSelectInput"
           />
           <!-- MOSS字数 -->
           <div class="btn-style">


### PR DESCRIPTION
![image](https://github.com/AICCOF/chatmoss-ui/assets/59086082/69a9c2ef-7879-4437-8adb-87cb247325e7)
当这里输入提示语之前是无法删除/的，网页端还好可以刷新，vscode插件插件只能按个回车解决了。

现在我实现了当用户输入/突然不想用提示语想自己输入问题的时候可以删除(本来刚开始这样想的)

当时发现select输入的内容压根不会和prompt.value的值同步后面又改了一下，直接用户想要输的话直接进入input模式